### PR TITLE
feat: generate all variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ you might need to apply patches manually if conflicts occur (this can happen wit
 ## future work
 
 - add dawn & moon palettes
+
+## Contributing
+
+This theme is built using [bloom](https://github.com/rose-pine/rose-pine-bloom):
+
+```sh
+# Install bloom
+curl -sf http://goblin.run/github.com/rose-pine/rose-pine-bloom@v2 | sh
+
+# Build themes
+rose-pine-bloom template.patch
+```

--- a/dist/rose-pine-dawn/rose-pine-dawn-foam.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-foam.patch
@@ -9,16 +9,16 @@
 -static const char col_gray3[]       = "#bbbbbb";
 -static const char col_gray4[]       = "#eeeeee";
 -static const char col_cyan[]        = "#005577";
-+static const char col_gray1[]       = "#191724"; /* base */
-+static const char col_gray2[]       = "#1f1d2e"; /* surface */
-+static const char col_gray3[]       = "#908caa"; /* subtle */
-+static const char col_gray4[]       = "#e0def4"; /* text */
-+static const char col_cyan[]        = "#eb6f92"; /* love */
++static const char col_gray1[]       = "#faf4ed"; /* base */
++static const char col_gray2[]       = "#fffaf3"; /* surface */
++static const char col_gray3[]       = "#797593"; /* subtle */
++static const char col_gray4[]       = "#575279"; /* text */
++static const char col_cyan[]        = "#56949f"; /* foam */
  static const char *colors[][3]      = {
  	/*               fg         bg         border   */
  	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
 -	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
-+	[SchemeSel]  = { col_gray1, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#fffaf3", col_cyan,  col_cyan  },
  };
  
  /* tagging */

--- a/dist/rose-pine-dawn/rose-pine-dawn-foam.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-foam.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-dawn/rose-pine-dawn-gold.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-gold.patch
@@ -1,6 +1,6 @@
 --- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:05:59.032439800 +0200
-@@ -7,11 +7,11 @@
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };
  static const char dmenufont[]       = "monospace:size=10";
@@ -9,11 +9,16 @@
 -static const char col_gray3[]       = "#bbbbbb";
 -static const char col_gray4[]       = "#eeeeee";
 -static const char col_cyan[]        = "#005577";
-+static const char col_gray1[]       = "#191724"; /* base */
-+static const char col_gray2[]       = "#1f1d2e"; /* surface */
-+static const char col_gray3[]       = "#908caa"; /* subtle */
-+static const char col_gray4[]       = "#e0def4"; /* text */
-+static const char col_cyan[]        = "#31748f"; /* pine */
++static const char col_gray1[]       = "#faf4ed"; /* base */
++static const char col_gray2[]       = "#fffaf3"; /* surface */
++static const char col_gray3[]       = "#797593"; /* subtle */
++static const char col_gray4[]       = "#575279"; /* text */
++static const char col_cyan[]        = "#ea9d34"; /* gold */
  static const char *colors[][3]      = {
  	/*               fg         bg         border   */
  	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#fffaf3", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-dawn/rose-pine-dawn-gold.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-gold.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-dawn/rose-pine-dawn-iris.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-iris.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-dawn/rose-pine-dawn-iris.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-iris.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#faf4ed"; /* base */
++static const char col_gray2[]       = "#fffaf3"; /* surface */
++static const char col_gray3[]       = "#797593"; /* subtle */
++static const char col_gray4[]       = "#575279"; /* text */
++static const char col_cyan[]        = "#907aa9"; /* iris */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#fffaf3", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-dawn/rose-pine-dawn-love.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-love.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-dawn/rose-pine-dawn-love.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-love.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#faf4ed"; /* base */
++static const char col_gray2[]       = "#fffaf3"; /* surface */
++static const char col_gray3[]       = "#797593"; /* subtle */
++static const char col_gray4[]       = "#575279"; /* text */
++static const char col_cyan[]        = "#b4637a"; /* love */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#fffaf3", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-dawn/rose-pine-dawn-pine.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-pine.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#faf4ed"; /* base */
++static const char col_gray2[]       = "#fffaf3"; /* surface */
++static const char col_gray3[]       = "#797593"; /* subtle */
++static const char col_gray4[]       = "#575279"; /* text */
++static const char col_cyan[]        = "#286983"; /* pine */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#fffaf3", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-dawn/rose-pine-dawn-pine.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-pine.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-dawn/rose-pine-dawn-rose.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-rose.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#faf4ed"; /* base */
++static const char col_gray2[]       = "#fffaf3"; /* surface */
++static const char col_gray3[]       = "#797593"; /* subtle */
++static const char col_gray4[]       = "#575279"; /* text */
++static const char col_cyan[]        = "#d7827e"; /* rose */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#fffaf3", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-dawn/rose-pine-dawn-rose.patch
+++ b/dist/rose-pine-dawn/rose-pine-dawn-rose.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-moon/rose-pine-moon-foam.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-foam.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#232136"; /* base */
++static const char col_gray2[]       = "#2a273f"; /* surface */
++static const char col_gray3[]       = "#908caa"; /* subtle */
++static const char col_gray4[]       = "#e0def4"; /* text */
++static const char col_cyan[]        = "#9ccfd8"; /* foam */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#2a273f", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-moon/rose-pine-moon-foam.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-foam.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-moon/rose-pine-moon-gold.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-gold.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-moon/rose-pine-moon-gold.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-gold.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#232136"; /* base */
++static const char col_gray2[]       = "#2a273f"; /* surface */
++static const char col_gray3[]       = "#908caa"; /* subtle */
++static const char col_gray4[]       = "#e0def4"; /* text */
++static const char col_cyan[]        = "#f6c177"; /* gold */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#2a273f", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-moon/rose-pine-moon-iris.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-iris.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#232136"; /* base */
++static const char col_gray2[]       = "#2a273f"; /* surface */
++static const char col_gray3[]       = "#908caa"; /* subtle */
++static const char col_gray4[]       = "#e0def4"; /* text */
++static const char col_cyan[]        = "#c4a7e7"; /* iris */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#2a273f", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-moon/rose-pine-moon-iris.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-iris.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-moon/rose-pine-moon-love.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-love.patch
@@ -1,5 +1,5 @@
 --- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:07:14.876143278 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };
@@ -9,16 +9,16 @@
 -static const char col_gray3[]       = "#bbbbbb";
 -static const char col_gray4[]       = "#eeeeee";
 -static const char col_cyan[]        = "#005577";
-+static const char col_gray1[]       = "#191724"; /* base */
-+static const char col_gray2[]       = "#1f1d2e"; /* surface */
++static const char col_gray1[]       = "#232136"; /* base */
++static const char col_gray2[]       = "#2a273f"; /* surface */
 +static const char col_gray3[]       = "#908caa"; /* subtle */
 +static const char col_gray4[]       = "#e0def4"; /* text */
-+static const char col_cyan[]        = "#c4a7e7"; /* iris */
++static const char col_cyan[]        = "#eb6f92"; /* love */
  static const char *colors[][3]      = {
  	/*               fg         bg         border   */
  	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
 -	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
-+	[SchemeSel]  = { col_gray1, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#e0def4", col_cyan,  col_cyan  },
  };
  
  /* tagging */

--- a/dist/rose-pine-moon/rose-pine-moon-love.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-love.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-moon/rose-pine-moon-pine.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-pine.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine-moon/rose-pine-moon-pine.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-pine.patch
@@ -1,5 +1,5 @@
 --- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 14:57:51.825678985 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };
@@ -9,16 +9,16 @@
 -static const char col_gray3[]       = "#bbbbbb";
 -static const char col_gray4[]       = "#eeeeee";
 -static const char col_cyan[]        = "#005577";
-+static const char col_gray1[]       = "#191724"; /* base */
-+static const char col_gray2[]       = "#1f1d2e"; /* surface */
++static const char col_gray1[]       = "#232136"; /* base */
++static const char col_gray2[]       = "#2a273f"; /* surface */
 +static const char col_gray3[]       = "#908caa"; /* subtle */
 +static const char col_gray4[]       = "#e0def4"; /* text */
-+static const char col_cyan[]        = "#ebbcba"; /* rose */
++static const char col_cyan[]        = "#3e8fb0"; /* pine */
  static const char *colors[][3]      = {
  	/*               fg         bg         border   */
  	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
 -	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
-+	[SchemeSel]  = { col_gray1, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#e0def4", col_cyan,  col_cyan  },
  };
  
  /* tagging */

--- a/dist/rose-pine-moon/rose-pine-moon-rose.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-rose.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#232136"; /* base */
++static const char col_gray2[]       = "#2a273f"; /* surface */
++static const char col_gray3[]       = "#908caa"; /* subtle */
++static const char col_gray4[]       = "#e0def4"; /* text */
++static const char col_cyan[]        = "#ea9a97"; /* rose */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#2a273f", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine-moon/rose-pine-moon-rose.patch
+++ b/dist/rose-pine-moon/rose-pine-moon-rose.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine/rose-pine-foam.patch
+++ b/dist/rose-pine/rose-pine-foam.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#191724"; /* base */
++static const char col_gray2[]       = "#1f1d2e"; /* surface */
++static const char col_gray3[]       = "#908caa"; /* subtle */
++static const char col_gray4[]       = "#e0def4"; /* text */
++static const char col_cyan[]        = "#9ccfd8"; /* foam */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#1f1d2e", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine/rose-pine-foam.patch
+++ b/dist/rose-pine/rose-pine-foam.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine/rose-pine-gold.patch
+++ b/dist/rose-pine/rose-pine-gold.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#191724"; /* base */
++static const char col_gray2[]       = "#1f1d2e"; /* surface */
++static const char col_gray3[]       = "#908caa"; /* subtle */
++static const char col_gray4[]       = "#e0def4"; /* text */
++static const char col_cyan[]        = "#f6c177"; /* gold */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#1f1d2e", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine/rose-pine-gold.patch
+++ b/dist/rose-pine/rose-pine-gold.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine/rose-pine-iris.patch
+++ b/dist/rose-pine/rose-pine-iris.patch
@@ -1,5 +1,5 @@
 --- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:04:59.109094894 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };
@@ -13,12 +13,12 @@
 +static const char col_gray2[]       = "#1f1d2e"; /* surface */
 +static const char col_gray3[]       = "#908caa"; /* subtle */
 +static const char col_gray4[]       = "#e0def4"; /* text */
-+static const char col_cyan[]        = "#f6c177"; /* gold */
++static const char col_cyan[]        = "#c4a7e7"; /* iris */
  static const char *colors[][3]      = {
  	/*               fg         bg         border   */
  	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
 -	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
-+	[SchemeSel]  = { col_gray1, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#1f1d2e", col_cyan,  col_cyan  },
  };
  
  /* tagging */

--- a/dist/rose-pine/rose-pine-iris.patch
+++ b/dist/rose-pine/rose-pine-iris.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine/rose-pine-love.patch
+++ b/dist/rose-pine/rose-pine-love.patch
@@ -1,5 +1,5 @@
 --- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:06:41.099195024 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };
@@ -13,12 +13,12 @@
 +static const char col_gray2[]       = "#1f1d2e"; /* surface */
 +static const char col_gray3[]       = "#908caa"; /* subtle */
 +static const char col_gray4[]       = "#e0def4"; /* text */
-+static const char col_cyan[]        = "#9ccfd8"; /* foam */
++static const char col_cyan[]        = "#eb6f92"; /* love */
  static const char *colors[][3]      = {
  	/*               fg         bg         border   */
  	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
 -	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
-+	[SchemeSel]  = { col_gray1, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#e0def4", col_cyan,  col_cyan  },
  };
  
  /* tagging */

--- a/dist/rose-pine/rose-pine-love.patch
+++ b/dist/rose-pine/rose-pine-love.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine/rose-pine-pine.patch
+++ b/dist/rose-pine/rose-pine-pine.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#191724"; /* base */
++static const char col_gray2[]       = "#1f1d2e"; /* surface */
++static const char col_gray3[]       = "#908caa"; /* subtle */
++static const char col_gray4[]       = "#e0def4"; /* text */
++static const char col_cyan[]        = "#31748f"; /* pine */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#e0def4", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/dist/rose-pine/rose-pine-pine.patch
+++ b/dist/rose-pine/rose-pine-pine.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine/rose-pine-rose.patch
+++ b/dist/rose-pine/rose-pine-rose.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/dist/rose-pine/rose-pine-rose.patch
+++ b/dist/rose-pine/rose-pine-rose.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "#191724"; /* base */
++static const char col_gray2[]       = "#1f1d2e"; /* surface */
++static const char col_gray3[]       = "#908caa"; /* subtle */
++static const char col_gray4[]       = "#e0def4"; /* text */
++static const char col_cyan[]        = "#ebbcba"; /* rose */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "#1f1d2e", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */

--- a/template.patch
+++ b/template.patch
@@ -1,5 +1,5 @@
---- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
-+++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+--- a/config.def.h
++++ b/config.def.h
 @@ -7,15 +7,15 @@
  static const int topbar             = 1;        /* 0 means bottom bar */
  static const char *fonts[]          = { "monospace:size=10" };

--- a/template.patch
+++ b/template.patch
@@ -1,0 +1,24 @@
+--- config.def.h.bak	2024-08-04 14:30:15.918277792 +0200
++++ config.def.h	2024-08-04 15:02:53.709070654 +0200
+@@ -7,15 +7,15 @@
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+-static const char col_gray1[]       = "#222222";
+-static const char col_gray2[]       = "#444444";
+-static const char col_gray3[]       = "#bbbbbb";
+-static const char col_gray4[]       = "#eeeeee";
+-static const char col_cyan[]        = "#005577";
++static const char col_gray1[]       = "$base"; /* base */
++static const char col_gray2[]       = "$surface"; /* surface */
++static const char col_gray3[]       = "$subtle"; /* subtle */
++static const char col_gray4[]       = "$text"; /* text */
++static const char col_cyan[]        = "$accent"; /* $accentname */
+ static const char *colors[][3]      = {
+ 	/*               fg         bg         border   */
+ 	[SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+-	[SchemeSel]  = { col_gray4, col_cyan,  col_cyan  },
++	[SchemeSel]  = { "$onaccent", col_cyan,  col_cyan  },
+ };
+ 
+ /* tagging */


### PR DESCRIPTION
**WIP**

This uses a custom build of our [bloom](https://github.com/rose-pine/rose-pine-bloom) tool to add all the variants for this theme. I am not sure if a string can be used for `[SchemeSel]`.

_If_ this does work, I'll update here once we release a version of bloom that has official support for this syntax :)